### PR TITLE
fixes error 131 when using adobe acrobat ( #19 ) 

### DIFF
--- a/pcarstracks.tex
+++ b/pcarstracks.tex
@@ -10,7 +10,7 @@
 \usepackage[]{eso-pic}[2002/11/16]
 \usepackage{fancybox} % fuer Oval...
 \renewcommand\familydefault{\sfdefault}
-
+\pdfminorversion=4
 %
 % TOC stuff
 %


### PR DESCRIPTION
first (best) fix: don't use adobe
second: force pdf minor version to 4.
